### PR TITLE
Sets the NODE_ENV, defaulting to production

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cp -r src/stagecoach/example/deployment src/YOURAPPHERE/deployment
 
 5. Edit `deployment/settings` and set `PROJECT` to the shortname of your project (usually, the directory name).
 
-6. Edit `deployment/settings.production`. Make sure `USER` matches the non-root username on the server and `SERVER` is the hostname of your server. Create additional `settings.*` files if you have additional servers to deploy to, such as `staging`.
+6. Edit `deployment/settings.production`. Make sure `USER` matches the non-root username on the server and `SERVER` is the hostname of your server. Create additional `settings.*` files if you have additional servers to deploy to, such as `staging`, also setting `NODE_ENV` to something other than `production` as appropriate.
 
 7. Deploy to production for the first time:
 
@@ -251,6 +251,10 @@ This command will attempt to connect as root rather than the username found in `
 `sc-proxy` is a node.js-based frontend proxy server solution for web apps that listen on independent ports, built on top of the `node-http-proxy` module. It picks up port numbers directly from the Stagecoach `data/port` files. It's a neat proof of concept, but we've found that performance is much better with nginx (see above). If you're still interested in sc-proxy, check out the `README.md` in that subdirectory for more information.
 
 ## Changelog
+
+3/29/2019:
+
+* Adds the setting of `NODE_ENV` in deployment settings.
 
 12/23/2016:
 

--- a/bin/sc-deploy
+++ b/bin/sc-deploy
@@ -93,7 +93,7 @@ ssh -p $SSH_PORT $USER@$SERVER $ALLOW_FOR_SUDO <<EOM
     rm -rf $CURRENT &&
     ln -s $DEPLOYTO $CURRENT &&
     cd $CURRENT &&
-    bash deployment/start
+    bash deployment/start $NODE_ENV
     OUTCOME="\$?"
   fi
   # If deployment failed, relink and restart the previous deployment
@@ -105,7 +105,7 @@ ssh -p $SSH_PORT $USER@$SERVER $ALLOW_FOR_SUDO <<EOM
       ln -s \$FORMER $CURRENT &&
       if [ \$STOPPED -eq 1 ]; then
         echo "Restarting previous deployment" &&
-        cd $CURRENT && bash deployment/start
+        cd $CURRENT && bash deployment/start $NODE_ENV
       fi
     fi
     echo "Removing failed deployment"

--- a/example/deployment/settings.production
+++ b/example/deployment/settings.production
@@ -7,3 +7,4 @@
 
 USER=nodeapps
 SERVER=example.com
+NODE_ENV=production

--- a/example/deployment/start
+++ b/example/deployment/start
@@ -16,6 +16,16 @@ if [ ! -f "app.js" ]; then
   exit 1
 fi
 
+if [ -z "$1" ] ; then
+  echo 'ℹ️  No NODE_ENV set in deployment settings. Defaulting to "production"'
+  NODE_ENV=production
+else
+  NODE_ENV=$1
+fi
+
+# Set the environment as production.
+export NODE_ENV=$NODE_ENV
+
 # Assign a port number if we don't yet have one
 
 if [ -f "data/port" ]; then

--- a/example/package.json
+++ b/example/package.json
@@ -1,8 +1,8 @@
 {
-  "author": "P'unk Avenue <tom@punkave.com> (http://punkave.com/)",
-  "name": "example",
-  "description": "Example node app run and deployed under stagecoach",
-  "version": "1.1.0",
+  "author": "P'unk Avenue",
+  "name": "stagecoach",
+  "description": "Stagecoach is a simple framework for deploying node.js web applications to your own servers.",
+  "version": "1.2.0",
   "homepage": "http://github.com/punkave/stagecoach",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The intention behind this is to default to [better performance and security](https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production).

The big question seem to be whether this would override the environment settings set somewhere else.